### PR TITLE
Fix for bootstrap dropdown menu's

### DIFF
--- a/_layouts/bootstrap.html
+++ b/_layouts/bootstrap.html
@@ -81,6 +81,7 @@
 
     <script src="/javascripts/jquery-1.8.1.min.js"></script>
     <script src="/vendor/bootstrap-2.3.1/js/bootstrap-tab.js"></script>
+    <script src="/vendor/bootstrap-2.3.1/js/bootstrap-dropdown.js"></script>
     <script src="/javascripts/bootstrap-tab-memory.js"></script>
   </body>
 </html>


### PR DESCRIPTION
The dropdown menu's of the Cucumber wiki are not working for a few weeks now. The issue was that the bootstrap-dropdown.js file is missing.
