### PR TITLE
Adding in instructions for running via CLI/Ant

### DIFF
--- a/running.md
+++ b/running.md
@@ -16,7 +16,48 @@ you are using (if any).
  
 ## Running Cucumber-JVM
 ### Command Line
-TODO
+This is only mildly complicated due to the need to specify a classpath etc.
+
+In short, use the following script:
+{% highlight bash %}
+CLASSPATH=lib/*
+CLASSPATH=$CLASSPATH:classes
+CLASSPATH=$CLASSPATH:test-classes
+
+java \
+    -classpath $CLASSPATH \
+    cucumber.api.cli.Main \
+    --glue foldername \ # the foldername containing compiled glue code
+    path/to/feature/folder
+{% endhighlight %}
+
+In this example, the directory structure looks like so (slightly modified from the Cucumber-JVM "Hello World" example):
+
+```
+lib/
+    cucumber-core.jar
+    cucumber-java.jar
+    cucumber-jvm-deps.jar
+    gherkin.jar
+src/
+    main/java/skeleton/Belly.java
+    test/
+         java/skeleton/Stepdefs.java
+         resources/cucumber.properties
+         resources/skeleton/belly.feature
+```
+
+The sources are compiled into two folders: target/classes for the actual code, and target/test-classes for step definitions known as "glue code".
+This then explains the classpath settings in the script above:
+
+1. The lib folder containing the Cucumber jars.
+2. The compiled source code.
+3. The compiled glue code.
+
+...and also the argument to '--glue'.
+
+Running the above script should (if everything works correctly) run your features.
+
 ### JUnit
 Create one empty class with the `@RunWith(Cucumber.class)` annotation. 
 Executing this class as any JUnit test class will run all features found on the classpath in the same package as this class.
@@ -35,14 +76,43 @@ public class RunCukesTest {
 {% endhighlight %}
 ### TestNG
 TODO
+
 ### Android
 TODO
+
 #### Android options
 TODO
+
 ### Maven
 TODO
+
 ### Ant
-TODO
+Apart from the usual classpath/compile/clean targets, to actually run Cucumber-JVM you will need the following xml.
+Note that the 'compile-test' target compiles the test classes which include the glue code for steps etc.
+It uses the same directory structure as the Command-line example above.
+
+{% highlight xml %}
+    <target name="runcukes" depends="compile-test">
+        <java classname="cucumber.api.cli.Main" fork="true" 
+            failonerror="false" resultproperty="cucumber.exitstatus">
+            <classpath refid="classpath"/>
+            <arg value="--glue"/>
+            <arg value="skeleton"/>
+            <arg value="src/test/resources"/>
+        </java>
+
+        <fail message="Cucumber failed">
+            <condition>
+                <not>
+                    <equals arg1="${cucumber.exitstatus}" arg2="0"/>
+                </not>
+            </condition>
+        </fail>
+    </target>
+{% endhighlight %}
+
+Simply run `ant runcukes` to run the tests.
+
 ### Gradle
 TODO
 


### PR DESCRIPTION
I'm adding in the sections for running Cucumber-JVM via the command line, and with Ant. Based heavily off the examples in the Cucumber-java-helloworld repo, but it's a good starting point.

Now with less merge conflicts. :beers:
